### PR TITLE
Simplify metrics

### DIFF
--- a/crates/folo/src/io/completion_port.rs
+++ b/crates/folo/src/io/completion_port.rs
@@ -108,8 +108,6 @@ impl !Send for CompletionPort {}
 impl !Sync for CompletionPort {}
 
 thread_local! {
-    static PRIMITIVES_BOUND: Event = EventBuilder::new()
-        .name("isolated_io_primitives_bound")
-        .build()
-        .unwrap();
+    static PRIMITIVES_BOUND: Event = EventBuilder::new("isolated_io_primitives_bound")
+        .build();
 }

--- a/crates/folo/src/io/completion_port_shared.rs
+++ b/crates/folo/src/io/completion_port_shared.rs
@@ -91,8 +91,6 @@ impl CompletionPortShared {
 }
 
 thread_local! {
-    static PRIMITIVES_BOUND: Event = EventBuilder::new()
-        .name("shared_io_primitives_bound")
-        .build()
-        .unwrap();
+    static PRIMITIVES_BOUND: Event = EventBuilder::new("shared_io_primitives_bound")
+        .build();
 }

--- a/crates/folo/src/io/driver.rs
+++ b/crates/folo/src/io/driver.rs
@@ -165,27 +165,19 @@ impl Drop for Driver {
 const ASYNC_COMPLETIONS_DEQUEUED_BUCKETS: &[Magnitude] = &[0, 1, 16, 64, 256, 512];
 
 thread_local! {
-    static ASYNC_COMPLETIONS_DEQUEUED: Event = EventBuilder::new()
-        .name("io_async_completions_dequeued")
+    static ASYNC_COMPLETIONS_DEQUEUED: Event = EventBuilder::new("io_async_completions_dequeued")
         .buckets(ASYNC_COMPLETIONS_DEQUEUED_BUCKETS)
-        .build()
-        .unwrap();
+        .build();
 
     // With sleep time == 0.
-    static POLL_TIMEOUTS: Event = EventBuilder::new()
-        .name("io_async_completions_poll_timeouts")
-        .build()
-        .unwrap();
+    static POLL_TIMEOUTS: Event = EventBuilder::new("io_async_completions_poll_timeouts")
+        .build();
 
     // With sleep time != 0.
-    static WAIT_TIMEOUTS: Event = EventBuilder::new()
-        .name("io_async_completions_wait_timeouts")
-        .build()
-        .unwrap();
+    static WAIT_TIMEOUTS: Event = EventBuilder::new("io_async_completions_wait_timeouts")
+        .build();
 
-    static GET_COMPLETED_DURATION: Event = EventBuilder::new()
-        .name("io_async_completions_get_duration_millis")
+    static GET_COMPLETED_DURATION: Event = EventBuilder::new("io_async_completions_get_duration_millis")
         .buckets(GENERAL_MILLISECONDS_BUCKETS)
-        .build()
-        .unwrap();
+        .build();
 }

--- a/crates/folo/src/io/driver_shared.rs
+++ b/crates/folo/src/io/driver_shared.rs
@@ -148,20 +148,14 @@ impl Drop for DriverShared {
 const ASYNC_COMPLETIONS_DEQUEUED_BUCKETS: &[Magnitude] = &[0, 1, 16, 64, 256, 512];
 
 thread_local! {
-    static ASYNC_COMPLETIONS_DEQUEUED: Event = EventBuilder::new()
-        .name("io_shared_async_completions_dequeued")
+    static ASYNC_COMPLETIONS_DEQUEUED: Event = EventBuilder::new("io_shared_async_completions_dequeued")
         .buckets(ASYNC_COMPLETIONS_DEQUEUED_BUCKETS)
-        .build()
-        .unwrap();
+        .build();
 
-    static POLL_TIMEOUTS: Event = EventBuilder::new()
-        .name("io_shared_async_completions_poll_timeouts")
-        .build()
-        .unwrap();
+    static POLL_TIMEOUTS: Event = EventBuilder::new("io_shared_async_completions_poll_timeouts")
+        .build();
 
-    static GET_COMPLETED_DURATION: Event = EventBuilder::new()
-        .name("io_shared_async_completions_get_duration_millis")
+    static GET_COMPLETED_DURATION: Event = EventBuilder::new("io_shared_async_completions_get_duration_millis")
         .buckets(GENERAL_MILLISECONDS_BUCKETS)
-        .build()
-        .unwrap();
+        .build();
 }

--- a/crates/folo/src/io/operation.rs
+++ b/crates/folo/src/io/operation.rs
@@ -501,30 +501,20 @@ impl Drop for Operation {
 }
 
 thread_local! {
-    static OPERATIONS_ALLOCATED: Event = EventBuilder::new()
-        .name("io_ops_allocated")
-        .build()
-        .unwrap();
+    static OPERATIONS_ALLOCATED: Event = EventBuilder::new("io_ops_allocated")
+        .build();
 
-    static OPERATIONS_COMPLETED_ASYNC: Event = EventBuilder::new()
-        .name("io_ops_completed_async")
-        .build()
-        .unwrap();
+    static OPERATIONS_COMPLETED_ASYNC: Event = EventBuilder::new("io_ops_completed_async")
+        .build();
 
-    static OPERATIONS_COMPLETED_SYNC: Event = EventBuilder::new()
-        .name("io_ops_completed_sync")
-        .build()
-        .unwrap();
+    static OPERATIONS_COMPLETED_SYNC: Event = EventBuilder::new("io_ops_completed_sync")
+        .build();
 
-    static OPERATION_COMPLETED_BYTES: Event = EventBuilder::new()
-        .name("io_completed_bytes")
+    static OPERATION_COMPLETED_BYTES: Event = EventBuilder::new("io_completed_bytes")
         .buckets(GENERAL_BYTES_BUCKETS)
-        .build()
-        .unwrap();
+        .build();
 
-    static OPERATION_COMPLETED_ASYNC_OK_DURATION: Event = EventBuilder::new()
-        .name("io_completed_async_ok_duration_millis")
+    static OPERATION_COMPLETED_ASYNC_OK_DURATION: Event = EventBuilder::new("io_completed_async_ok_duration_millis")
         .buckets(GENERAL_MILLISECONDS_BUCKETS)
-        .build()
-        .unwrap();
+        .build();
 }

--- a/crates/folo/src/io/operation_shared.rs
+++ b/crates/folo/src/io/operation_shared.rs
@@ -492,30 +492,20 @@ impl Drop for OperationShared {
 }
 
 thread_local! {
-    static OPERATIONS_ALLOCATED: Event = EventBuilder::new()
-        .name("io_shared_ops_allocated")
-        .build()
-        .unwrap();
+    static OPERATIONS_ALLOCATED: Event = EventBuilder::new("io_shared_ops_allocated")
+        .build();
 
-    static OPERATIONS_COMPLETED_ASYNC: Event = EventBuilder::new()
-        .name("io_shared_ops_completed_async")
-        .build()
-        .unwrap();
+    static OPERATIONS_COMPLETED_ASYNC: Event = EventBuilder::new("io_shared_ops_completed_async")
+        .build();
 
-    static OPERATIONS_COMPLETED_SYNC: Event = EventBuilder::new()
-        .name("io_shared_ops_completed_sync")
-        .build()
-        .unwrap();
+    static OPERATIONS_COMPLETED_SYNC: Event = EventBuilder::new("io_shared_ops_completed_sync")
+        .build();
 
-    static OPERATION_COMPLETED_BYTES: Event = EventBuilder::new()
-        .name("io_shared_completed_bytes")
+    static OPERATION_COMPLETED_BYTES: Event = EventBuilder::new("io_shared_completed_bytes")
         .buckets(GENERAL_BYTES_BUCKETS)
-        .build()
-        .unwrap();
+        .build();
 
-    static OPERATION_COMPLETED_ASYNC_OK_DURATION: Event = EventBuilder::new()
-        .name("io_shared_completed_async_ok_duration_millis")
+    static OPERATION_COMPLETED_ASYNC_OK_DURATION: Event = EventBuilder::new("io_shared_completed_async_ok_duration_millis")
         .buckets(GENERAL_MILLISECONDS_BUCKETS)
-        .build()
-        .unwrap();
+        .build();
 }

--- a/crates/folo/src/io/pinned_buffer.rs
+++ b/crates/folo/src/io/pinned_buffer.rs
@@ -315,23 +315,15 @@ thread_local! {
     static POOL: RefCell<PinnedSlabChain<UnsafeCell<[u8; POOL_BUFFER_CAPACITY_BYTES]>>> =
         RefCell::new(PinnedSlabChain::new(DropPolicy::MustNotDropItems));
 
-    static CALLER_BUFFERS_REFERENCED: Event = EventBuilder::new()
-        .name("isolated_caller_buffers_referenced")
-        .build()
-        .unwrap();
+    static CALLER_BUFFERS_REFERENCED: Event = EventBuilder::new("isolated_caller_buffers_referenced")
+        .build();
 
-    static CALLER_POINTERS_REFERENCED: Event = EventBuilder::new()
-        .name("isolated_caller_pointers_referenced")
-        .build()
-        .unwrap();
+    static CALLER_POINTERS_REFERENCED: Event = EventBuilder::new("isolated_caller_pointers_referenced")
+        .build();
 
-    static POOL_ALLOCATED: Event = EventBuilder::new()
-        .name("isolated_pool_buffers_allocated")
-        .build()
-        .unwrap();
+    static POOL_ALLOCATED: Event = EventBuilder::new("isolated_pool_buffers_allocated")
+        .build();
 
-    static POOL_DROPPED: Event = EventBuilder::new()
-        .name("isolated_pool_buffers_dropped")
-        .build()
-        .unwrap();
+    static POOL_DROPPED: Event = EventBuilder::new("isolated_pool_buffers_dropped")
+        .build();
 }

--- a/crates/folo/src/io/pinned_buffer_shared.rs
+++ b/crates/folo/src/io/pinned_buffer_shared.rs
@@ -257,18 +257,12 @@ const POOL_BUFFER_CAPACITY_BYTES: usize = 64 * 1024;
 link_ref!(static POOL: SharedArrayPool<POOL_BUFFER_CAPACITY_BYTES> = SharedArrayPool::new());
 
 thread_local! {
-    static CALLER_BUFFERS_REFERENCED: Event = EventBuilder::new()
-        .name("shared_caller_buffers_referenced")
-        .build()
-        .unwrap();
+    static CALLER_BUFFERS_REFERENCED: Event = EventBuilder::new("shared_caller_buffers_referenced")
+        .build();
 
-    static CALLER_POINTERS_REFERENCED: Event = EventBuilder::new()
-        .name("shared_caller_pointers_referenced")
-        .build()
-        .unwrap();
+    static CALLER_POINTERS_REFERENCED: Event = EventBuilder::new("shared_caller_pointers_referenced")
+        .build();
 
-    static POOL_RENTED: Event = EventBuilder::new()
-        .name("shared_pool_buffers_rented")
-        .build()
-        .unwrap();
+    static POOL_RENTED: Event = EventBuilder::new("shared_pool_buffers_rented")
+        .build();
 }

--- a/crates/folo/src/rt/async_agent.rs
+++ b/crates/folo/src/rt/async_agent.rs
@@ -501,23 +501,15 @@ enum ProcessCommandsResult {
 }
 
 thread_local! {
-    static LOCAL_TASKS: Event = EventBuilder::new()
-        .name("rt_async_tasks_local")
-        .build()
-        .unwrap();
+    static LOCAL_TASKS: Event = EventBuilder::new("rt_async_tasks_local")
+        .build();
 
-    static REMOTE_TASKS: Event = EventBuilder::new()
-        .name("rt_async_tasks_remote")
-        .build()
-        .unwrap();
+    static REMOTE_TASKS: Event = EventBuilder::new("rt_async_tasks_remote")
+        .build();
 
-    static CYCLES_WITH_SLEEP: Event = EventBuilder::new()
-        .name("rt_async_cycles_with_sleep")
-        .build()
-        .unwrap();
+    static CYCLES_WITH_SLEEP: Event = EventBuilder::new("rt_async_cycles_with_sleep")
+        .build();
 
-    static CYCLES_WITHOUT_SLEEP: Event = EventBuilder::new()
-        .name("rt_async_cycles_without_sleep")
-        .build()
-        .unwrap();
+    static CYCLES_WITHOUT_SLEEP: Event = EventBuilder::new("rt_async_cycles_without_sleep")
+        .build();
 }

--- a/crates/folo/src/rt/async_task_engine.rs
+++ b/crates/folo/src/rt/async_task_engine.rs
@@ -221,10 +221,6 @@ impl AsyncTaskEngine {
 
         CYCLE_DURATION.with(|x| x.observe_millis(cycle_end.duration_since(cycle_start)));
 
-        if self.completed.len() > 10000 {
-            println!("Completed: {}, Active: {}, Inactive: {}", self.completed.len(), self.active.len(), self.inactive.len());
-        }
-
         if self.shutting_down && self.completed.is_empty() {
             // Shutdown is finished if all completed tasks (== all tasks) have been removed from the
             // completed list after their wakers became inert.

--- a/crates/folo/src/rt/async_task_engine.rs
+++ b/crates/folo/src/rt/async_task_engine.rs
@@ -221,6 +221,10 @@ impl AsyncTaskEngine {
 
         CYCLE_DURATION.with(|x| x.observe_millis(cycle_end.duration_since(cycle_start)));
 
+        if self.completed.len() > 10000 {
+            println!("Completed: {}, Active: {}, Inactive: {}", self.completed.len(), self.active.len(), self.inactive.len());
+        }
+
         if self.shutting_down && self.completed.is_empty() {
             // Shutdown is finished if all completed tasks (== all tasks) have been removed from the
             // completed list after their wakers became inert.
@@ -449,50 +453,32 @@ impl Debug for Task {
 }
 
 thread_local! {
-    static TASKS_CANCELED_ON_SHUTDOWN: Event = EventBuilder::new()
-        .name("rt_async_tasks_canceled_on_shutdown")
-        .build()
-        .unwrap();
+    static TASKS_CANCELED_ON_SHUTDOWN: Event = EventBuilder::new("rt_async_tasks_canceled_on_shutdown")
+        .build();
 
-    static TASK_ACTIVATED_VIA_SET: Event = EventBuilder::new()
-        .name("rt_async_task_activated_via_set")
-        .build()
-        .unwrap();
+    static TASK_ACTIVATED_VIA_SET: Event = EventBuilder::new("rt_async_task_activated_via_set")
+        .build();
 
-    static TASK_ACTIVATED_VIA_SIGNAL: Event = EventBuilder::new()
-        .name("rt_async_task_activated_via_signal")
-        .build()
-        .unwrap();
+    static TASK_ACTIVATED_VIA_SIGNAL: Event = EventBuilder::new("rt_async_task_activated_via_signal")
+        .build();
 
-    static TASK_ACTIVATED_SPURIOUS: Event = EventBuilder::new()
-        .name("rt_async_task_activated_spurious")
-        .build()
-        .unwrap();
+    static TASK_ACTIVATED_SPURIOUS: Event = EventBuilder::new("rt_async_task_activated_spurious")
+        .build();
 
-    static TASK_INACTIVATED: Event = EventBuilder::new()
-        .name("rt_async_task_inactivated")
-        .build()
-        .unwrap();
+    static TASK_INACTIVATED: Event = EventBuilder::new("rt_async_task_inactivated")
+        .build();
 
-    static TASKS_COMPLETED: Event = EventBuilder::new()
-        .name("rt_async_tasks_completed")
-        .build()
-        .unwrap();
+    static TASKS_COMPLETED: Event = EventBuilder::new("rt_async_tasks_completed")
+        .build();
 
-    static TASKS_DROPPED: Event = EventBuilder::new()
-        .name("rt_async_tasks_dropped")
-        .build()
-        .unwrap();
+    static TASKS_DROPPED: Event = EventBuilder::new("rt_async_tasks_dropped")
+        .build();
 
-    static CYCLE_INTERVAL: Event = EventBuilder::new()
-        .name("rt_async_cycle_interval_millis")
+    static CYCLE_INTERVAL: Event = EventBuilder::new("rt_async_cycle_interval_millis")
         .buckets(GENERAL_MILLISECONDS_BUCKETS)
-        .build()
-        .unwrap();
+        .build();
 
-    static CYCLE_DURATION: Event = EventBuilder::new()
-        .name("rt_async_cycle_duration_millis")
+    static CYCLE_DURATION: Event = EventBuilder::new("rt_async_cycle_duration_millis")
         .buckets(GENERAL_MILLISECONDS_BUCKETS)
-        .build()
-        .unwrap();
+        .build();
 }

--- a/crates/folo/src/rt/remote_result_box.rs
+++ b/crates/folo/src/rt/remote_result_box.rs
@@ -116,20 +116,14 @@ impl<R> RemoteResultBox<R> {
 }
 
 thread_local! {
-    static FILL_DURATION: Event = EventBuilder::new()
-        .name("result_box_remote_time_to_fill_millis")
+    static FILL_DURATION: Event = EventBuilder::new("result_box_remote_time_to_fill_millis")
         .buckets(GENERAL_MILLISECONDS_BUCKETS)
-        .build()
-        .unwrap();
+        .build();
 
-    static CONSUME_DURATION: Event = EventBuilder::new()
-        .name("result_box_remote_time_to_consume_millis")
+    static CONSUME_DURATION: Event = EventBuilder::new("result_box_remote_time_to_consume_millis")
         .buckets(GENERAL_MILLISECONDS_BUCKETS)
-        .build()
-        .unwrap();
+        .build();
 
-    static POLL_COUNT: Event = EventBuilder::new()
-        .name("result_box_remote_poll_count")
-        .build()
-        .unwrap();
+    static POLL_COUNT: Event = EventBuilder::new("result_box_remote_poll_count")
+        .build();
 }

--- a/crates/folo/src/rt/runtime_client.rs
+++ b/crates/folo/src/rt/runtime_client.rs
@@ -570,21 +570,15 @@ fn next_sync_processor(max: usize) -> usize {
 }
 
 thread_local! {
-    static REMOTE_SPAWN_DELAY: Event = EventBuilder::new()
-        .name("rt_remote_spawn_delay_millis")
+    static REMOTE_SPAWN_DELAY: Event = EventBuilder::new("rt_remote_spawn_delay_millis")
         .buckets(GENERAL_MILLISECONDS_BUCKETS)
-        .build()
-        .unwrap();
+        .build();
 
-    static SYNC_SPAWN_DELAY_HIGH_PRIORITY: Event = EventBuilder::new()
-        .name("rt_sync_spawn_delay_high_priority_millis")
+    static SYNC_SPAWN_DELAY_HIGH_PRIORITY: Event = EventBuilder::new("rt_sync_spawn_delay_high_priority_millis")
         .buckets(GENERAL_MILLISECONDS_BUCKETS)
-        .build()
-        .unwrap();
+        .build();
 
-    static SYNC_SPAWN_DELAY_LOW_PRIORITY: Event = EventBuilder::new()
-        .name("rt_sync_spawn_delay_low_priority_millis")
+    static SYNC_SPAWN_DELAY_LOW_PRIORITY: Event = EventBuilder::new("rt_sync_spawn_delay_low_priority_millis")
         .buckets(GENERAL_MILLISECONDS_BUCKETS)
-        .build()
-        .unwrap();
+        .build();
 }

--- a/crates/folo/src/rt/sync_agent.rs
+++ b/crates/folo/src/rt/sync_agent.rs
@@ -119,33 +119,23 @@ pub enum SyncAgentCommand {
 const QUEUE_SIZE_BUCKETS: &[Magnitude] = &[0, 1, 10, 100, 1000];
 
 thread_local! {
-    static TASKS: Event = EventBuilder::new()
-        .name("rt_sync_tasks")
-        .build()
-        .unwrap();
+    static TASKS: Event = EventBuilder::new("rt_sync_tasks")
+        .build();
 
-    static TASK_DURATION: Event = EventBuilder::new()
-        .name("rt_sync_task_duration_millis")
+    static TASK_DURATION: Event = EventBuilder::new("rt_sync_task_duration_millis")
         .buckets(GENERAL_MILLISECONDS_BUCKETS)
-        .build()
-        .unwrap();
+        .build();
 
-    static TASK_INTERVAL: Event = EventBuilder::new()
-        .name("rt_sync_task_interval_millis")
+    static TASK_INTERVAL: Event = EventBuilder::new("rt_sync_task_interval_millis")
         .buckets(GENERAL_MILLISECONDS_BUCKETS)
-        .build()
-        .unwrap();
+        .build();
 
-    static LOW_PRIORITY_QUEUE_SIZE: Event = EventBuilder::new()
-        .name("rt_sync_low_priority_queue_size")
+    static LOW_PRIORITY_QUEUE_SIZE: Event = EventBuilder::new("rt_sync_low_priority_queue_size")
         .buckets(QUEUE_SIZE_BUCKETS)
-        .build()
-        .unwrap();
+        .build();
 
-    static HIGH_PRIORITY_QUEUE_SIZE: Event = EventBuilder::new()
-        .name("rt_sync_high_priority_queue_size")
+    static HIGH_PRIORITY_QUEUE_SIZE: Event = EventBuilder::new("rt_sync_high_priority_queue_size")
         .buckets(QUEUE_SIZE_BUCKETS)
-        .build()
-        .unwrap();
+        .build();
 
 }

--- a/crates/folo/tests/shutdown.rs
+++ b/crates/folo/tests/shutdown.rs
@@ -127,8 +127,7 @@ fn runtime_stops_with_external_observer() {
     // We manually create the runtime here because we need to also operate outside of it.
     let folo = RuntimeBuilder::new()
         .worker_init(folo_testing::init_test_worker)
-        .build()
-        .unwrap();
+        .build();
     let folo_clone = folo.clone();
 
     let (tx, rx) = oneshot::channel();
@@ -175,8 +174,7 @@ fn runtime_stops_with_external_dependency() {
     // We manually create the runtime here because we need to also operate outside of it.
     let folo = RuntimeBuilder::new()
         .worker_init(folo_testing::init_test_worker)
-        .build()
-        .unwrap();
+        .build();
 
     let nexus = Arc::new(ManualFuture::new());
     let nexus_folo = Arc::clone(&nexus);


### PR DESCRIPTION
The name is always provided so require it in the constructor. This allows us to have failure-free build method.