### PR TITLE
refactor: Switch from RefCell to OnceCell to get rid of runtime checks

### DIFF
--- a/crates/folo/src/rt/current_async_agent.rs
+++ b/crates/folo/src/rt/current_async_agent.rs
@@ -1,5 +1,5 @@
 use crate::{io, rt::async_agent::AsyncAgent};
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::OnceCell, rc::Rc};
 
 /// Executes a closure that receives the current thread's async agent for the runtime that owns the
 /// current thread. The agent provides low-level access to Folo runtime internals for this thread.
@@ -11,9 +11,9 @@ pub fn with<F, R>(f: F) -> R
 where
     F: FnOnce(&AsyncAgent) -> R,
 {
-    CURRENT_AGENT.with_borrow(|agent| {
+    CURRENT_AGENT.with(|agent| {
         f(agent
-            .as_ref()
+            .get()
             .expect("this thread is not an async worker thread owned by the Folo runtime"))
     })
 }
@@ -29,9 +29,9 @@ pub fn with_io<F, R>(f: F) -> R
 where
     F: FnOnce(&mut io::Driver) -> R,
 {
-    CURRENT_AGENT.with_borrow(|agent| {
+    CURRENT_AGENT.with(|agent| {
         agent
-            .as_ref()
+            .get()
             .expect("this thread is not an async worker thread owned by the Folo runtime")
             .with_io(f)
     })
@@ -48,9 +48,9 @@ pub fn with_io_shared<F, R>(f: F) -> R
 where
     F: FnOnce(&io::DriverShared) -> R,
 {
-    CURRENT_AGENT.with_borrow(|agent| {
+    CURRENT_AGENT.with(|agent| {
         agent
-            .as_ref()
+            .get()
             .expect("this thread is not an async worker thread owned by the Folo runtime")
             .with_io_shared(f)
     })
@@ -63,23 +63,21 @@ pub fn try_with_io<F, R>(f: F) -> Option<R>
 where
     F: FnOnce(&mut io::Driver) -> R,
 {
-    CURRENT_AGENT.with_borrow(|agent| agent.as_ref().map(|agent| agent.with_io(f)))
+    CURRENT_AGENT.with(|agent| agent.get().map(|agent| agent.with_io(f)))
 }
 
 pub fn is_some() -> bool {
-    CURRENT_AGENT.with_borrow(|agent| agent.is_some())
+    CURRENT_AGENT.with(|agent| agent.get().is_some())
 }
 
 pub fn set(value: Rc<AsyncAgent>) {
-    CURRENT_AGENT.with_borrow_mut(|agent| {
-        if agent.is_some() {
-            panic!("this thread is already registered to a Folo runtime");
-        }
-
-        *agent = Some(value);
+    CURRENT_AGENT.with(|agent| {
+        agent
+            .set(value)
+            .expect("this thread is already registered to a Folo runtime");
     });
 }
 
 thread_local!(
-    static CURRENT_AGENT: RefCell<Option<Rc<AsyncAgent>>> = const { RefCell::new(None) }
+    static CURRENT_AGENT: OnceCell<Rc<AsyncAgent>> = OnceCell::new();
 );


### PR DESCRIPTION
One small thing I noticed while reading the code :)